### PR TITLE
Remove API key after regneration

### DIFF
--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -110,9 +110,6 @@ $container['PHPWarks\Welcome\HomeAction'] = function ($c) {
 $container['PHPWarks\API\Internal\Events\UpcomingAction'] = function ($c) {
     return new PHPWarks\API\Internal\Events\UpcomingAction(
         $c->get('api.meetup'),
-        [
-            'sign' => true,
-            'key'  => '683d6d3f25744ae5d631c1a424437',
-        ]
+        []
     );
 };


### PR DESCRIPTION
It seems you do not require the API key to even hit their API?!?

 - [x] Regenerate the API key for meetup.com
 - [x] Remove any reference of the API key in the codebase